### PR TITLE
Update README with recent talks from Guild

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,53 @@ Our current venues:
 
 * [Microsoft Reactor London](https://reactor.microsoft.com/en-us/reactor/) - Shoreditch
 * [Outverse](https://www.outverse.com/) - Spitalfields
+
+## Our latest Talks
+
+### January 2023 Meetup
+
+**Live collab should be the default way of building web apps** - Werner Stucky
+
+- The technology theory and algorithms exist to easily make all web-based software collaborative (aka Google Doc-like)
+- Yjs is a great library to easily implement CRDTs into web based software
+- SvelteKit and Yjs work amazingly well together when combined with Svelte Stores
+
+**A Business Case for SvelteKit** - by Chris Ellis
+
+Chris is director of engineering at XtendOps and in this talk he details the reasoning behind moving his company from Meteor to SvelteKit
+
+**Using the Svelte use action for animations** - by Scott Spence
+
+https://www.youtube.com/watch?v=UPF-oHPyxWM
+
+### December 2022 Meetup
+
+**Mistakes we made building Sveltekit** - by Rich Harris
+
+Reflections on two years of getting stuff wrong in public.
+
+**SvelteKit Vendure eCommerce Showcase** - by Scott Spence
+
+A brief overview of the storefront-sveltekit-starter I created with the help of @jycouet and the technologies used.
+
+**uSinG tHe PlaTFoRm** - by Antony Jones
+
+Leveraging the platform in SvelteKit
+
+https://www.youtube.com/watch?v=2ijSarsHfN0
+
+### November 2022 Meetup
+
+**Sharable State** - by Paolo Ricciuti
+
+Lift your state up to the URL. When to do it, how to do it and what's the new best way to do it.
+
+**Moving from React to Svelte, progressively** - by Fergus Leahy
+
+How we're progressively moving an actively worked on codebase (with 4 engineers) into SvelteKit, to enable us to progressively enhance the frontend with Svelte + Kit whilst minimising impact on product velocity.
+
+https://www.youtube.com/watch?v=DXQl1G54DJY
+
+---
+
+To have a look at some of our older talks, check us out [on YouTube](https://www.youtube.com/@SvelteSociety/streams), or have a look at the [archived Meetup group](https://www.meetup.com/svelte/).


### PR DESCRIPTION
While all of the Svelte London meetup talks are listed on Guild and Meetup, it's not easy for our anyone interested in the meetup to have a look at all the previous talks. This PR is an attempt to index the talks listed on Guild well. This will help anyone looking at this particular repo to get a taste of what Svelte London is, and also make the content more SEO friendly.

Future work involves adding future meetups on this, and also adding the previous Meetup talks one-by-one.